### PR TITLE
Fixed bounds checking for colorTemp attribute

### DIFF
--- a/CHANGED
+++ b/CHANGED
@@ -1,5 +1,5 @@
 LedController last change:
-2017-01-07
- - fixed typo
- - Merge branch 'master' of https://github.com/patrickjahns/esp_rgbww_fhemmodule
+2017-01-31
+ - Merge pull request #6 from patrickjahns/develop
 
+Develop

--- a/FHEM/32_LedController.pm
+++ b/FHEM/32_LedController.pm
@@ -371,8 +371,8 @@ LedController_Attr(@) {
   my ($cmd, $device, $attribName, $attribVal) = @_;
   my $hash = $defs{$device};
 
+  return "colorTemp must be a value from 2700 to 6000, inclusively." if ! LedController_rangeCheck($attribVal, 2700, 6000);
   if ($cmd eq 'set' && $attribName eq 'colorTemp'){
-  return "colorTemp must be between 2000 and 10000" if ! LedController_rangeCheck($attribVal, 2000, 10000);
   }
   # TODO: Add checks for defaultColor, defaultHue/Sat/Val here!
   Log3 ($hash, 4, "$hash->{NAME} attrib $attribName $cmd $attribVal") if $attribVal && ($hash->{helper}->{logLevel} >= 4); 

--- a/controls_ledcontroller.txt
+++ b/controls_ledcontroller.txt
@@ -1,2 +1,2 @@
 DEL ./FHEM/32_LedController.pm
-UPD 2017-01-07_22:08:31 49524 FHEM/32_LedController.pm
+UPD 2017-01-31_00:11:20 50793 FHEM/32_LedController.pm


### PR DESCRIPTION
Controller accepts range from 2700 to 6000.
Values outside that range will result in 50/50 mixing of WW/CW in RGBWWCW mode.

And sorry about the CHANGED file... ;)